### PR TITLE
Version 2: Optimised connection flow and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ wq <- WifiQueue(cm, WIFIQUEUE_HIDDEN | WIFIQUEUE_OPEN)
 
 wq
 	.onConnect(function() {
-		logger.log("WifiQueue connected to " + imp.getssid());
+		server.log("WifiQueue connected to " + imp.getssid());
 	})
 	.onFail(function() {
-		logger.error("WifiQueue failed to connect");
-	});
+		// Failed to connect...
+	})
 	.connect(wifis);
 ```
 
@@ -65,6 +65,11 @@ This flag indicates whether any wifis listed in `wifiList` might be hidden.  If 
 
 This flag indicates whether WifiQueue should try to connect to an visible
 networks that are open.
+
+#### WIFIQUEUE\_DEBUG
+
+This flag indicates whether WifiQueue should log debug info to the logger
+object, such as failed connection attempts.
 
 ## Connection Management
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WifiQueue 3.0.0
+# WifiQueue 2.0.0
 
 The WifiQueue class is an Electric Imp device side library to allow the device to attempt to connect to a supplied list of WiFi networks.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ wq
 
 ## Constructor: WifiQueue(*cm[, flags[, logger]]*)
 
-The WifiQueue class is instantiated with a ConnectionManager object and two optional parameters, wifiList and logs.
+The WifiQueue class is instantiated with a ConnectionManager object and two optional parameters, `flags` and `logger`.
 
 **NOTE:** The WifiQueue class requires the ConnectionManager's `retry` parameter to be set to `false`, as seen below.
 
@@ -103,7 +103,7 @@ wq.disconnect();
 
 ### onConnect(*callback*)
 
-Sets a callback to be trigger whenever the device connects.
+Sets a callback to be trigger whenever the device connects.  The callback will also be triggered immediately if `.connect()` is called while the device is already connected.
 
 ```squirrel
 wq.onConnect(function() {

--- a/WifiQueue.class.nut
+++ b/WifiQueue.class.nut
@@ -174,10 +174,12 @@ class WifiQueue {
     // -----------------------
     // Callback to run when WifiQueue fails to connect to any network
     function _didFail() {
+        // If there's no callback, or debug is set, then log this failure
+        if (!_onFail || _debug) {
+            _logger.error("WifiQueue failed to connect");
+        }
         if (_onFail) {
             _onFail();
-        } else {
-            _logger.error("WifiQueue failed to connect");
         }
     }
 

--- a/WifiQueue.class.nut
+++ b/WifiQueue.class.nut
@@ -64,18 +64,14 @@ class WifiQueue {
             // Cancel any in-progress wardriving
             _warDriving = false;
 
-             // Copy the array because we will be mutating it, and we need to be the
+            // Copy the array because we will be mutating it, and we need to be the
             // only ones
-            _wifis = clone(wifis || []);
-
-            // Remove invalid entries
-            for (local i = _wifis.len() - 1; i >= 0; i--) {
-                local n = _wifis[i];
-                if (!("ssid" in n && n.ssid.len() > 0 && "pw" in n)) {
-                    _debug && _logger.error("WifiQueue invalid wifi: " + i);
-                    _wifis.remove(i);
-                }
+            _wifis = clone(wifis || []).filter(@(n) "ssid" in n && "pw" in n);
+            local invalid = wifis.len() - _wifis.len();
+            if (invalid > 0 && _debug) {
+                _logger.error("WifiQueue invalid wifis: " + invalid);
             }
+
         }
 
         if (_connecting) {

--- a/WifiQueue.class.nut
+++ b/WifiQueue.class.nut
@@ -66,7 +66,7 @@ class WifiQueue {
 
             // Copy the array because we will be mutating it, and we need to be the
             // only ones
-            _wifis = clone(wifis || []).filter(@(n) "ssid" in n && "pw" in n);
+            _wifis = clone(wifis || []).filter(@(_, n) "ssid" in n && "pw" in n);
             local invalid = wifis.len() - _wifis.len();
             if (invalid > 0 && _debug) {
                 _logger.error("WifiQueue invalid wifis: " + invalid);
@@ -207,7 +207,7 @@ class WifiQueue {
         } else if (_open && !_warDriving) {
             // We are done with all our known networks, let's have a go at wardriving!
             // Reset our "known" list of wifis to the list of all open visible networks.
-            _wifis = visible.filter(@(nw) nw.open).map(@(nw) { "ssid": nw.ssid, "pw": "" });
+            _wifis = visible.filter(@(_, nw) nw.open).map(@(nw) { "ssid": nw.ssid, "pw": "" });
             if (_wifis.len()) {
                 // Try the first one
                 return _wifis.remove(0);

--- a/WifiQueue.class.nut
+++ b/WifiQueue.class.nut
@@ -8,52 +8,70 @@ const WIFIQUEUE_OPEN   = 0x02;
 class WifiQueue {
     static version = [3, 0, 0];
 
+    // Connection manager instance
     _cm = null;
+    // List of wifi networks to try
     _wifis = null;
+    // Whether we are currently trying to connect to a network
     _connecting = false;
+    // Whether we should try networks that are not visible (because they may be hidden)
     _hidden = null;
+    // Whether we should try open wifi networks (that are not in the list we were given)
     _open = null;
     // Whether we have scanned for open wifi networks to initiate warDriving yet
     _warDriving = false;
 
+    // Callbacks
     _onFail = null;
     _onConnect = null;
     _onDisconnect = null;
 
     // -----------------------
-    // wifis should be an [ { ssid, pw } ]
-    // `hidden` is whether to try networks in `wifis` even if they are not visible
-    // `open` is whether to try open networks
-    constructor(cm, wifis = null, flags = null, logger = server) {
+    // `cm` is a connection manager instance
+    // `wifis` is an [ { ssid, pw } ]
+    // `flags` is a bit-array of boolean options`
+    // `logger` is a logger object with `.log()` and `.error()` methods
+    constructor(cm, flags = null, logger = server) {
         _cm = cm;
-
-        // Copy the array because we will be mutating it, and we need to be the
-        // only ones
-        _wifis = clone(wifis || []);
-
-        // Remove invalid entries
-        for (local i = _wifis.len() - 1; i >= 0; i--) {
-            local n = _wifis[i];
-            if (!("ssid" in n && n.ssid.len() > 0 && "pw" in n)) {
-                logger.error("invalid wifi: " + i);
-                _wifis.remove(i);
-            }
-        }
 
         // Process options
         flags = flags || 0;
         _hidden = flags & WIFIQUEUE_HIDDEN;
         _open   = flags & WIFIQUEUE_OPEN;
 
+        // Set ConnectionManager callbacks
         _cm.onConnect(_didConnect.bindenv(this));
         _cm.onTimeout(_didTimeout.bindenv(this));
         _cm.onDisconnect(_didDisconnect.bindenv(this));
     }
 
-
     // -----------------------
-    // Attempt to connect to each network in the list until the first successful connection
-    function connect() {
+    // Attempt to connect to list of wifis
+    //
+    // Other methods of this class which call this method "recursively"
+    // e.g. `.didTimeout()` will call method with `_reset == false` to
+    // avoid resetting the wifi list each time.  When called from outside a
+    // list of wifi networks should be passed in to initialize this
+    // connecting attempt.
+    function connect(wifis = null, _reset = true) {
+        if (_reset) {
+            // Cancel any in-progress wardriving
+            _warDriving = false;
+
+             // Copy the array because we will be mutating it, and we need to be the
+            // only ones
+            _wifis = clone(wifis || []);
+
+            // Remove invalid entries
+            for (local i = _wifis.len() - 1; i >= 0; i--) {
+                local n = _wifis[i];
+                if (!("ssid" in n && n.ssid.len() > 0 && "pw" in n)) {
+                    logger.error("invalid wifi: " + i);
+                    _wifis.remove(i);
+                }
+            }
+        }
+
         if (_connecting) {
             return false;
         }
@@ -79,6 +97,7 @@ class WifiQueue {
 
 
     // -----------------------
+    // Set the onConnect callback
     function onConnect(callback) {
         _onConnect = callback;
         return this;
@@ -86,6 +105,9 @@ class WifiQueue {
 
 
     // -----------------------
+    // Set the onFail callback
+    //
+    // This will run when WifiQueue fails to connect to any network
     function onFail(callback) {
         _onFail = callback;
         return this;
@@ -123,7 +145,7 @@ class WifiQueue {
             imp.setwificonfiguration(next.ssid, next.pw);
 
             // Try to connect
-            connect();
+            connect(null, false);
         } else {
             // No next network to try, we're all out of ideas
             return _onFail();
@@ -132,11 +154,13 @@ class WifiQueue {
 
 
     // -----------------------
+    // Callback to run when device disconnects
     function _didDisconnect(expected) {
         _connecting = false;
         if (_onDisconnect) _onDisconnect(expected);
-        if (!expected && !_connecting) {
-            connect();
+        if (!expected) {
+            // Try again
+            connect(null, false);
         }
     }
 
@@ -160,10 +184,10 @@ class WifiQueue {
 
         // No visible networks are known...
         if (_wifis.len() && _hidden && !_warDriving) {
-            // We have known, untried networks and we are supposed to try them
-            // all.  Just grab the first one.
-            // Note that if we are warDriving already, then we know there
-            // aren't any hidden networks in the list anymore
+            // We have known networks and we are supposed to try them all.
+            // Just grab the first one.  Note that if we are warDriving
+            // already, then we know there aren't any hidden networks in the
+            // list anymore, so we won't go down this path
             return _wifis.remove(0);
         } else if (_open && !_warDriving) {
             // We are done with all our known networks, let's have a go at wardriving!

--- a/WifiQueue.class.nut
+++ b/WifiQueue.class.nut
@@ -7,7 +7,7 @@ const WIFIQUEUE_OPEN   = 0x02;
 const WIFIQUEUE_DEBUG  = 0x04;
 
 class WifiQueue {
-    static version = [3, 0, 0];
+    static version = [2, 0, 0];
 
     // Connection manager instance
     _cm = null;

--- a/WifiQueue.class.nut
+++ b/WifiQueue.class.nut
@@ -20,6 +20,8 @@ class WifiQueue {
     _open = null;
     // Whether we have scanned for open wifi networks to initiate warDriving yet
     _warDriving = false;
+    // Logger object
+    _logger = null;
 
     // Callbacks
     _onFail = null;
@@ -33,6 +35,7 @@ class WifiQueue {
     // `logger` is a logger object with `.log()` and `.error()` methods
     constructor(cm, flags = null, logger = server) {
         _cm = cm;
+        _logger = logger;
 
         // Process options
         flags = flags || 0;
@@ -66,7 +69,7 @@ class WifiQueue {
             for (local i = _wifis.len() - 1; i >= 0; i--) {
                 local n = _wifis[i];
                 if (!("ssid" in n && n.ssid.len() > 0 && "pw" in n)) {
-                    logger.error("invalid wifi: " + i);
+                    _logger.error("invalid wifi: " + i);
                     _wifis.remove(i);
                 }
             }
@@ -126,7 +129,7 @@ class WifiQueue {
     // Callback to run when device connects
     function _didConnect() {
         _connecting = false;
-        logger.log("Connected to network: " + imp.getssid());
+        _logger.log("Connected to network: " + imp.getssid());
         if (_onConnect) _onConnect();
     }
 
@@ -135,7 +138,7 @@ class WifiQueue {
     // Callback to run when device times out connecting to a network
     function _didTimeout() {
         _connecting = false;
-        logger.log("Could not connect to network: " + imp.getssid());
+        _logger.log("Could not connect to network: " + imp.getssid());
 
         // Select the next network to try
         local next = _pop();


### PR DESCRIPTION
This pull request implements the following optimised connection flow:

1. Try to connect to the currently configured network.  This should normally be the last successfully configured network, and should have a high success rate if the device doesn't move around too much.
2. Try to connect to any visible, known networks.  Pick networks closer to the front of `wifiList` first if there are multiple candidates.
3. If WIFIQUEUE\_HIDDEN is set, try to connect to any other networks remaining in `wifiList`.
4. If WIFIQUEUE\_OPEN is set, call `imp.scanwifinetworks()` once to get a list of visible, open networks.  Try to connect to each in turn, as long as it remains visible at the time of attempting to connect.
5. If we have still not managed to connect to any network, call the `onFail` callback.

@dbns97 please review